### PR TITLE
Replace wrong text

### DIFF
--- a/cli/src/main/java/io/quarkiverse/tekton/cli/pipeline/PipelineExec.java
+++ b/cli/src/main/java/io/quarkiverse/tekton/cli/pipeline/PipelineExec.java
@@ -18,7 +18,7 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Unmatched;
 
-@Command(name = "exec", header = "Execute Tekton pipelines.")
+@Command(name = "exec", header = "Execute Tekton pipeline.")
 public class PipelineExec extends AbstractPipelineCommand {
 
     @Parameters(index = "0", paramLabel = "PIPELINE", description = "Pipeline name.")

--- a/cli/src/main/java/io/quarkiverse/tekton/cli/pipeline/PipelineInstall.java
+++ b/cli/src/main/java/io/quarkiverse/tekton/cli/pipeline/PipelineInstall.java
@@ -15,7 +15,7 @@ public class PipelineInstall extends AbstractPipelineCommand {
     @Parameters(index = "0", arity = "0..1", paramLabel = "pipeline", description = "Pipeline name.")
     Optional<String> pipelineName;
 
-    @Option(names = { "--all" }, description = "Install all plugins in the catalog.")
+    @Option(names = { "--all" }, description = "Install all the pipelines.")
     boolean all;
 
     @Option(names = { "-r", "--regenerate" }, description = "Regenerate and reinstall the pipeline.")

--- a/cli/src/main/java/io/quarkiverse/tekton/cli/pipeline/PipelineUninstall.java
+++ b/cli/src/main/java/io/quarkiverse/tekton/cli/pipeline/PipelineUninstall.java
@@ -14,7 +14,7 @@ import picocli.CommandLine.Parameters;
 public class PipelineUninstall extends AbstractPipelineCommand {
 
     @Option(names = {
-            "--all" }, defaultValue = "", paramLabel = "all", order = 6, description = "Install all plugins in the catalog.")
+            "--all" }, defaultValue = "", paramLabel = "all", order = 6, description = "Uninstall all the pipelines.")
     boolean all;
 
     @Parameters(index = "0", arity = "0..1", paramLabel = "pipeline", description = "Pipeline name.")

--- a/cli/src/main/java/io/quarkiverse/tekton/cli/task/TaskExec.java
+++ b/cli/src/main/java/io/quarkiverse/tekton/cli/task/TaskExec.java
@@ -18,7 +18,7 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.Unmatched;
 
-@Command(name = "exec", header = "Execute Tekton tasks.")
+@Command(name = "exec", header = "Execute Tekton task.")
 public class TaskExec extends AbstractTaskCommand {
 
     @Parameters(index = "0", paramLabel = "TASK", description = "Task name.")

--- a/cli/src/main/java/io/quarkiverse/tekton/cli/task/TaskInstall.java
+++ b/cli/src/main/java/io/quarkiverse/tekton/cli/task/TaskInstall.java
@@ -15,7 +15,7 @@ public class TaskInstall extends AbstractTaskCommand {
     @Parameters(index = "0", arity = "0..1", paramLabel = "TASK", description = "Task name.")
     Optional<String> taskName;
 
-    @Option(names = { "--all" }, description = "Install all plugins in the catalog.")
+    @Option(names = { "--all" }, description = "Uninstall all the tasks.")
     boolean all;
 
     @Option(names = { "-r", "--regenerate" }, description = "Regenerate and reinstall the task.")

--- a/cli/src/main/java/io/quarkiverse/tekton/cli/task/TaskUninstall.java
+++ b/cli/src/main/java/io/quarkiverse/tekton/cli/task/TaskUninstall.java
@@ -14,7 +14,7 @@ import picocli.CommandLine.Parameters;
 public class TaskUninstall extends AbstractTaskCommand {
 
     @Option(names = {
-            "--all" }, defaultValue = "", paramLabel = "all", order = 6, description = "Install all plugins in the catalog.")
+            "--all" }, defaultValue = "", paramLabel = "all", order = 6, description = "Install all the tasks.")
     boolean all;
 
     @Parameters(index = "0", arity = "0..1", paramLabel = "TASK", description = "Task name.")


### PR DESCRIPTION
- Replace wrong text describing the option `--all` and use the singular form for the exec command (task or pipeline)