### PR TITLE
Imrpve the code to avoid to pass as argument: dockerfile

### DIFF
--- a/common/src/main/java/io/quarkiverse/tekton/pipeline/BuildTestPushPipeline.java
+++ b/common/src/main/java/io/quarkiverse/tekton/pipeline/BuildTestPushPipeline.java
@@ -1,19 +1,13 @@
 package io.quarkiverse.tekton.pipeline;
 
 import io.fabric8.tekton.v1.Pipeline;
-import io.fabric8.tekton.v1.PipelineBuilder;
 import io.quarkiverse.tekton.common.utils.Resources;
 import io.quarkiverse.tekton.common.utils.Serialization;
-import io.quarkiverse.tekton.visitors.AddParamSpecDefaultValue;
 
 public class BuildTestPushPipeline {
 
     public static Pipeline create() {
         Pipeline pipeline = Serialization.unmarshal(Resources.read("/tekton/pipelines/build-test-push.yaml"));
-        pipeline = new PipelineBuilder(pipeline)
-                .accept(
-                        new AddParamSpecDefaultValue("DOCKERFILE", "src/main/docker/Dockerfile.jvm"))
-                .build();
         return pipeline;
     }
 }

--- a/common/src/main/java/io/quarkiverse/tekton/task/BuildahTask.java
+++ b/common/src/main/java/io/quarkiverse/tekton/task/BuildahTask.java
@@ -1,18 +1,13 @@
 package io.quarkiverse.tekton.task;
 
 import io.fabric8.tekton.v1.Task;
-import io.fabric8.tekton.v1.TaskBuilder;
 import io.quarkiverse.tekton.common.utils.Resources;
 import io.quarkiverse.tekton.common.utils.Serialization;
-import io.quarkiverse.tekton.visitors.AddParamSpecDefaultValue;
 
 public class BuildahTask {
 
     public static Task create() {
         Task task = Serialization.unmarshal(Resources.read("/tekton/tasks/buildah.yaml"));
-        task = new TaskBuilder(task)
-                .accept(new AddParamSpecDefaultValue("DOCKERFILE", "src/main/docker/Dockerfile.jvm"))
-                .build();
         return task;
     }
 }

--- a/common/src/main/resources/tekton/pipelines/build-test-push.yaml
+++ b/common/src/main/resources/tekton/pipelines/build-test-push.yaml
@@ -10,6 +10,7 @@ spec:
     - name: dockerfile
       type: string
       description: Path to the dockerfile within the project cloned
+      default: "src/main/docker/Dockerfile.jvm"
     - name: output-image
       type: string
       description: Fully Qualified Output Image
@@ -69,6 +70,8 @@ spec:
       params:
         - name: IMAGE
           value: $(params.output-image)
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
         # THIS IS MANDATORY TO PASS THE CREDS FILE TO THE TASK FROM THE WKS
         - name: REGISTRY_AUTH_PATH
           value: $(workspaces.dockerconfig-secret.path)

--- a/common/src/main/resources/tekton/tasks/buildah.yaml
+++ b/common/src/main/resources/tekton/tasks/buildah.yaml
@@ -26,7 +26,7 @@ spec:
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
     type: string
-  - default: ./Dockerfile
+  - default: src/main/docker/Dockerfile.jvm
     description: Path to the Dockerfile to build.
     name: DOCKERFILE
     type: string


### PR DESCRIPTION
- Set as default value for the Dockerfile param `src/main/docker/Dockerfile.jvm` instead of `./Dockerfile` for the buildah task
- Pass the parameter from the pipelinerun to the pipeline task's buildah as param: DOCKERFILE

Tested successfully without the dockerfile arg from a HelloWorld Quarkus example
```
k delete -n demo pipelinerun --all
k delete -n demo pipeline --all
k delete -n demo tasks --all
rm -f ".tekton/tekton.*"
qt generate
qt task install --all
qt pipeline install build-test-push
qt pipeline exec build-test-push output-image=quay.io/ikanello/my-quarkus-app:latest url=https://github.com/iocanel/hello-backstage.git

pipelinerun succeeded
```

BUT this command will fail as Buildah task cannot find the path of the Dockerfile

```
qt pipeline exec build-test-push output-image=quay.io/ikanello/my-quarkus-app:latest url=https://github.com/iocanel/hello-backstage.git dockerfile=src/main/docker/Dockerfile.jvm666
❯ tkn pr logs build-test-push-run
...
task buildah-image has failed: "step-build" exited with code 1
[buildah-image : build] Cannot find Dockerfile src/main/docker/Dockerfile.jvm666

failed to get logs for task buildah-image : container step-build has failed  : [{"key":"StartedAt","value":"2025-03-27T15:09:02.176Z","type":3}]
Tasks Completed: 3 (Failed: 1, Cancelled 0), Skipped: 0
```


