### PR TITLE
Review the code to support to pass an array of goals to maven

### DIFF
--- a/common/src/main/java/io/quarkiverse/tekton/common/utils/Params.java
+++ b/common/src/main/java/io/quarkiverse/tekton/common/utils/Params.java
@@ -59,9 +59,20 @@ public final class Params {
     }
 
     public static Param create(String name, Object value) {
-        String stringVal = value instanceof String ? (String) value : null;
+        String stringVal = null;
         String[] arrayVal = value instanceof String[] ? (String[]) value : null;
         Map<String, String> objectVal = value instanceof Map ? (Map) value : null;
+
+        if (value instanceof String) {
+            // Try to split the content of the string to see if the content could be split into an array
+            // using as separator a space
+            String val = (String) value;
+            if (val.split(" ").length > 1) {
+                arrayVal = val.split(" ");
+            } else {
+                stringVal = val;
+            }
+        }
 
         return new ParamBuilder()
                 .withName(name)

--- a/common/src/main/java/io/quarkiverse/tekton/common/utils/Params.java
+++ b/common/src/main/java/io/quarkiverse/tekton/common/utils/Params.java
@@ -63,6 +63,8 @@ public final class Params {
         String[] arrayVal = value instanceof String[] ? (String[]) value : null;
         Map<String, String> objectVal = value instanceof Map ? (Map) value : null;
 
+        // TODO: There could be edge cases where a param contains string enclosed in single or double quotes where space could be allowed inside them. Such
+        // cases are not yet supported !
         if (value instanceof String) {
             // Try to split the content of the string to see if the content could be split into an array
             // using as separator a space

--- a/common/src/main/resources/tekton/pipelines/build-test-push.yaml
+++ b/common/src/main/resources/tekton/pipelines/build-test-push.yaml
@@ -26,6 +26,9 @@ spec:
       default: "true"
       name: deploy
       type: string
+    - description: Maven goals
+      name: mavenGoals
+      type: array
   workspaces:
     - name: project-dir
     - name: maven-repo-dir
@@ -49,8 +52,7 @@ spec:
         - name: DOCKER_CONFIG
           value: $(workspaces.dockerconfig.path)/config.json
         - name: GOALS
-          value:
-            - package
+          value: [ "$(params.mavenGoals[*])" ]
       workspaces:
         - name: maven-settings
           workspace: maven-settings

--- a/common/src/main/resources/tekton/tasks/catalog/maven.yaml
+++ b/common/src/main/resources/tekton/tasks/catalog/maven.yaml
@@ -156,7 +156,8 @@ spec:
     - name: mvn-goals
       image: $(params.MAVEN_IMAGE)
       workingDir: $(workspaces.project-dir.path)/$(params.CONTEXT_DIR)
-      args: ["$(params.GOALS[*])"]
+      args:
+        - "$(params.GOALS[*])"
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532


### PR DESCRIPTION
- Review the code to support to pass an array of goals to maven
- Enhance the method `public static Param create(String name, Object value)` to split a string including " " as this is the case when we pass arguments for maven